### PR TITLE
add: parseを実装

### DIFF
--- a/src/User/Command/Command.cpp
+++ b/src/User/Command/Command.cpp
@@ -19,3 +19,39 @@ std::vector<std::string>	Command::get_args()
 {
 	return (this->args);
 }
+
+void    Command::parse(std::string buffer)
+{
+    // std::cout << buffer;
+    std::string delim = " ";
+
+    if (buffer.length() == 0)
+    {
+        std::cout << "no cmds";
+        return ;
+    }
+    //splitする
+    std::string elem = buffer.substr(0, buffer.find(delim));
+	std::cout << "elem: " << elem << std::endl;
+    //cmds vector 初期化
+    commands.resize(0);
+    //　スペースの一個めまでcmdに格納後、読み取った部分を消去
+    commands.push_back(elem);
+    buffer = buffer.erase(0, buffer.find(delim) + delim.length());
+    // prefixはとりあえず放置
+    // とりあえずそれ以外もargsに入れていく
+    //cmds vector 初期化
+    args.resize(0);
+    //bufferは51行目のeraseでスペースまでを削除して、最終的に両方消えるまで
+    while (buffer != elem)
+    {
+        elem = buffer.substr(0, buffer.find(delim));
+        std::cout << "on loop: " << elem << std::endl;
+        args.push_back(elem);
+        buffer = buffer.erase(0, buffer.find(delim) + delim.length());
+    }
+    for (unsigned int i =0; i < commands.size(); i++)
+        std::cout <<  "cmds elem is " << commands.at(i) << std::endl;
+    for (unsigned int i =0; i < args.size(); i++)
+        std::cout <<  "args elem is " << args.at(i) << std::endl;
+}

--- a/src/User/Command/Command.hpp
+++ b/src/User/Command/Command.hpp
@@ -3,6 +3,7 @@
 
 # include <string>
 # include <vector>
+# include <iostream>
 
 class Command
 {
@@ -14,7 +15,7 @@ class Command
 	public:
 		Command();
 
-		void		parse();
+		void		parse(std::string buffer);
 
 		std::string	get_prefix();
 		std::vector<std::string>	get_commands();

--- a/src/User/User.cpp
+++ b/src/User/User.cpp
@@ -29,6 +29,7 @@ void	User::receive()
 
 	bzero(buffer, BUFFER_MAX);
 	res = recv(fd, &buffer, BUFFER_MAX, 0);
+	std::cout << "res: " << res << std::endl;
 	if (res < 0)
 	{
 		std::exit (7);
@@ -39,10 +40,12 @@ void	User::receive()
 		this->is_exit = true;
 		// exit (8);
 	}
+	std::cout << "===================" << std::endl;
 	std::cout << buffer;
+	std::cout << "===================" << std::endl;
 	buffer[BUFFER_MAX] = '\0';
-
-	// command.parse(buffer);
+	//サーバーにメンバーが入った時にもrecvが反応してparseをしてしまう。弾く方法を考える必要あり
+	command.parse(buffer);
 }
 
 bool	User::get_is_exit()


### PR DESCRIPTION
## issue URL
#10 
## 対応内容・対応背景・妥協点
recvでキャッチした文字列を解析して、Userの中のcommandsの中のプライベート変数に格納する。

## やったこと
parceをCommandsクラスに実装。

## やってないこと

1. prefixの解釈
2. 複数コマンドの許容

## テスト
実際に動かしてコマンドと引数（args）の解釈が正しいかを確認。

## レビュー観点
修正案があったら追記頼んだ

- 想定通りに動作するか？
- より良い書き方はないか？
- より良い設計方法はないか？
- 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- 関数、コンポーネントの粒度は適切か？
- etc...

## 補足
